### PR TITLE
Valuetree

### DIFF
--- a/CrdtExamples.jucer
+++ b/CrdtExamples.jucer
@@ -14,6 +14,10 @@
               file="Source/crdtsimNetwork.cpp"/>
         <FILE id="bqM8dy" name="crdtsimNetwork.h" compile="0" resource="0"
               file="Source/crdtsimNetwork.h"/>
+        <FILE id="rPl5Gc" name="crdtsimNetworkComponent.cpp" compile="1" resource="0"
+              file="Source/crdtsimNetworkComponent.cpp"/>
+        <FILE id="NnhleM" name="crdtsimNetworkComponent.h" compile="0" resource="0"
+              file="Source/crdtsimNetworkComponent.h"/>
         <FILE id="uUtJTh" name="crdtsimNode.cpp" compile="1" resource="0" file="Source/crdtsimNode.cpp"/>
         <FILE id="ifcsQN" name="crdtsimNode.h" compile="0" resource="0" file="Source/crdtsimNode.h"/>
       </GROUP>

--- a/CrdtExamples.jucer
+++ b/CrdtExamples.jucer
@@ -26,9 +26,10 @@
     <XCODE_MAC targetFolder="Builds/MacOSX" extraCompilerFlags="-Wall -Wextra -Wpedantic">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" osxSDK="10.9 SDK" osxCompatibility="default" osxArchitecture="default"
-                       isDebug="1" optimisation="1" targetName="CrdtExamples"/>
+                       isDebug="1" optimisation="1" targetName="CrdtExamples" cppLanguageStandard="c++11"/>
         <CONFIGURATION name="Release" osxSDK="10.9 SDK" osxCompatibility="default" osxArchitecture="default"
-                       isDebug="0" optimisation="3" targetName="CrdtExamples" linkTimeOptimisation="1"/>
+                       isDebug="0" optimisation="3" targetName="CrdtExamples" linkTimeOptimisation="1"
+                       cppLanguageStandard="c++11"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_core" path="lib/JUCE/modules"/>

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -10,6 +10,7 @@
 #define MAINCOMPONENT_H_INCLUDED
 
 #include "../JuceLibraryCode/JuceHeader.h"
+#include "crdtsimNetworkComponent.h"
 
 //==============================================================================
 /*
@@ -22,6 +23,7 @@ public:
     //==============================================================================
     MainContentComponent ()
     {
+        addAndMakeVisible (&networkComponent);
         setSize (800, 600);
         setFramesPerSecond (60);
     }
@@ -47,18 +49,12 @@ public:
 
     void resized () override
     {
-        // This is called when the MainContentComponent is resized.
-        // If you add any child components, this is where you should
-        // update their positions.
+        networkComponent.setBounds (getLocalBounds ());
     }
 
 
 private:
-    //==============================================================================
-
-    // Your private member variables go here...
-
-
+    crdtsim::NetworkComponent networkComponent;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainContentComponent)
 };
 

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -11,6 +11,7 @@
 
 #include "../JuceLibraryCode/JuceHeader.h"
 #include "crdtsimNetworkComponent.h"
+#include "crdtsimNetwork.h"
 
 //==============================================================================
 /*
@@ -23,6 +24,11 @@ public:
     //==============================================================================
     MainContentComponent ()
     {
+        //MODEL
+        networkComponent.setNodesValueTree (network.getNodesValueTree ());
+        networkComponent.setConnexionsValueTree (network.getConnexionsValueTree ());
+        network.createNode ();
+        //VIEW
         addAndMakeVisible (&networkComponent);
         setSize (800, 600);
         setFramesPerSecond (60);
@@ -55,6 +61,7 @@ public:
 
 private:
     crdtsim::NetworkComponent networkComponent;
+    crdtsim::Network network;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainContentComponent)
 };
 

--- a/Source/crdtsimConnexionComponent.cpp
+++ b/Source/crdtsimConnexionComponent.cpp
@@ -1,0 +1,3 @@
+#include "crdtsimConnexionComponent.h"
+
+using namespace crdtsim;

--- a/Source/crdtsimConnexionComponent.h
+++ b/Source/crdtsimConnexionComponent.h
@@ -1,0 +1,10 @@
+#ifndef CRDTSIMCONNEXIONCOMPONENT_H_INCLUDED
+#define CRDTSIMCONNEXIONCOMPONENT_H_INCLUDED
+#include "JuceHeader.h"
+namespace crdtsim
+{
+class NodeComponent : public juce::Component
+{
+};
+} //namespace crdtsim
+#endif // CRDTSIMCONNEXIONCOMPONENT_H_INCLUDED

--- a/Source/crdtsimNetwork.cpp
+++ b/Source/crdtsimNetwork.cpp
@@ -81,6 +81,7 @@ bool Network::eraseConnexion (int sourceIdentifier, int destinationIdentifier)
         return false;
     }
     connexions.erase (findResult);
+    valueTree.removeChild (valueTree.getChildWithName (getConnexionIdentifier (sourceIdentifier, destinationIdentifier)), nullptr);
     return true;
 }
 bool Network::connexionExists (int sourceIdentifier, int destinationIdentifier)
@@ -267,6 +268,16 @@ public:
             auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
             network.createConnexion (nodeId1, nodeId2);
             expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
+        }
+        {
+            beginTest ("Network deletes a child to ValueTree when deleting a connexion.");
+            Network network;
+            auto nodeId1 = network.createNode ();
+            auto nodeId2 = network.createNode ();
+            network.createConnexion (nodeId1, nodeId2);
+            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            network.eraseConnexion (nodeId1, nodeId2);
+            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize - 1, "Network hasn't taken care of its tree.");
         }
     }
 } testTestNetwork;

--- a/Source/crdtsimNetwork.cpp
+++ b/Source/crdtsimNetwork.cpp
@@ -10,7 +10,7 @@ int Network::createNode ()
     auto newNode = Node{lastNodeIdentifier++};
     nodes.push_back (newNode);
     jassert (size () > 0);
-    valueTree.getOrCreateChildWithName (getNodeIdentifier (nodes.back ().getIdentifier ()), nullptr);
+    getNodesValueTree ().getOrCreateChildWithName (getNodeIdentifier (nodes.back ().getIdentifier ()), nullptr);
     jassert (valueTree.getNumChildren () > 0);
     return nodes.back ().getIdentifier ();
 }
@@ -41,7 +41,7 @@ bool Network::eraseNode (int identifier)
         return false;
     }
     nodes.erase (nodeToRemodeIt, std::end (nodes));
-    valueTree.removeChild (valueTree.getChildWithName (getNodeIdentifier (identifier)), nullptr);
+    getNodesValueTree ().removeChild (getNodesValueTree ().getChildWithName (getNodeIdentifier (identifier)), nullptr);
     eraseAllConnexionsWithNode (identifier);
     return true;
 }
@@ -67,7 +67,7 @@ bool Network::createConnexion (int sourceIdentifier, int destinationIdentifier)
     if (std::find (std::begin (connexions), std::end (connexions), connexionToAdd) == std::end (connexions))
     {
         connexions.push_back (connexionToAdd);
-        valueTree.getOrCreateChildWithName (getConnexionIdentifier (sourceIdentifier, destinationIdentifier), nullptr);
+        getConnexionsValueTree ().getOrCreateChildWithName (getConnexionIdentifier (sourceIdentifier, destinationIdentifier), nullptr);
     }
     return true;
 }
@@ -81,7 +81,7 @@ bool Network::eraseConnexion (int sourceIdentifier, int destinationIdentifier)
         return false;
     }
     connexions.erase (findResult);
-    valueTree.removeChild (valueTree.getChildWithName (getConnexionIdentifier (sourceIdentifier, destinationIdentifier)), nullptr);
+    getConnexionsValueTree ().removeChild (getConnexionsValueTree ().getChildWithName (getConnexionIdentifier (sourceIdentifier, destinationIdentifier)), nullptr);
     return true;
 }
 bool Network::connexionExists (int sourceIdentifier, int destinationIdentifier)
@@ -103,9 +103,13 @@ void Network::eraseAllConnexionsWithNode (int nodeIdentifier)
     };
     connexions.erase (std::remove_if (std::begin (connexions), std::end (connexions), sameDestinationPredicate), std::end (connexions));
 }
-juce::ValueTree& Network::getValueTree ()
+juce::ValueTree Network::getNodesValueTree ()
 {
-    return valueTree;
+    return valueTree.getOrCreateChildWithName ("NODES", nullptr);
+}
+juce::ValueTree Network::getConnexionsValueTree ()
+{
+    return valueTree.getOrCreateChildWithName ("CONNEXIONS", nullptr);
 }
 juce::Identifier Network::getNodeIdentifier (int nodeIdentifier)
 {
@@ -248,26 +252,26 @@ public:
         {
             beginTest ("Network creates a child to ValueTree when creating a node.");
             Network network;
-            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            auto initialValueTreeSize = network.getNodesValueTree ().getNumChildren ();
             network.createNode ();
-            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
+            expectEquals (network.getNodesValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
         }
         {
             beginTest ("Network deletes a child to ValueTree when deleting a node.");
             Network network;
             auto nodeId = network.createNode ();
-            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            auto initialValueTreeSize = network.getNodesValueTree ().getNumChildren ();
             network.eraseNode (nodeId);
-            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize - 1, "Network hasn't taken care of its tree.");
+            expectEquals (network.getNodesValueTree ().getNumChildren (), initialValueTreeSize - 1, "Network hasn't taken care of its tree.");
         }
         {
             beginTest ("Network creates a child to ValueTree when creating a connexion.");
             Network network;
             auto nodeId1 = network.createNode ();
             auto nodeId2 = network.createNode ();
-            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            auto initialValueTreeSize = network.getConnexionsValueTree ().getNumChildren ();
             network.createConnexion (nodeId1, nodeId2);
-            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
+            expectEquals (network.getConnexionsValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
         }
         {
             beginTest ("Network deletes a child to ValueTree when deleting a connexion.");
@@ -275,9 +279,9 @@ public:
             auto nodeId1 = network.createNode ();
             auto nodeId2 = network.createNode ();
             network.createConnexion (nodeId1, nodeId2);
-            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            auto initialValueTreeSize = network.getConnexionsValueTree ().getNumChildren ();
             network.eraseConnexion (nodeId1, nodeId2);
-            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize - 1, "Network hasn't taken care of its tree.");
+            expectEquals (network.getConnexionsValueTree ().getNumChildren (), initialValueTreeSize - 1, "Network hasn't taken care of its tree.");
         }
     }
 } testTestNetwork;

--- a/Source/crdtsimNetwork.cpp
+++ b/Source/crdtsimNetwork.cpp
@@ -67,6 +67,7 @@ bool Network::createConnexion (int sourceIdentifier, int destinationIdentifier)
     if (std::find (std::begin (connexions), std::end (connexions), connexionToAdd) == std::end (connexions))
     {
         connexions.push_back (connexionToAdd);
+        valueTree.getOrCreateChildWithName (getConnexionIdentifier (sourceIdentifier, destinationIdentifier), nullptr);
     }
     return true;
 }
@@ -108,6 +109,10 @@ juce::ValueTree& Network::getValueTree ()
 juce::Identifier Network::getNodeIdentifier (int nodeIdentifier)
 {
     return juce::String ("NODE#" + std::to_string (nodeIdentifier));
+}
+juce::Identifier Network::getConnexionIdentifier (int sourceIdentifier, int destinationIdentifier)
+{
+    return juce::String ("CONNEXION#" + std::to_string (sourceIdentifier) + "->" + std::to_string (destinationIdentifier));
 }
 
 
@@ -253,6 +258,15 @@ public:
             auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
             network.eraseNode (nodeId);
             expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize - 1, "Network hasn't taken care of its tree.");
+        }
+        {
+            beginTest ("Network creates a child to ValueTree when creating a connexion.");
+            Network network;
+            auto nodeId1 = network.createNode ();
+            auto nodeId2 = network.createNode ();
+            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            network.createConnexion (nodeId1, nodeId2);
+            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
         }
     }
 } testTestNetwork;

--- a/Source/crdtsimNetwork.cpp
+++ b/Source/crdtsimNetwork.cpp
@@ -1,9 +1,9 @@
 #include "crdtsimNetwork.h"
-#include "JuceHeader.h"
 #include <algorithm>
 
 namespace crdtsim
 {
+Network::Network () : valueTree ("RootNetwork") {}
 int Network::size () const { return nodes.size (); }
 int Network::createNode ()
 {
@@ -97,6 +97,10 @@ void Network::eraseAllConnexionsWithNode (int nodeIdentifier)
         return c.getDestinationNodeIdentifier () == nodeIdentifier;
     };
     connexions.erase (std::remove_if (std::begin (connexions), std::end (connexions), sameDestinationPredicate), std::end (connexions));
+}
+juce::ValueTree& Network::getValueTree ()
+{
+    return valueTree;
 }
 
 

--- a/Source/crdtsimNetwork.cpp
+++ b/Source/crdtsimNetwork.cpp
@@ -41,6 +41,7 @@ bool Network::eraseNode (int identifier)
         return false;
     }
     nodes.erase (nodeToRemodeIt, std::end (nodes));
+    valueTree.removeChild (valueTree.getChildWithName (getNodeIdentifier (identifier)), nullptr);
     eraseAllConnexionsWithNode (identifier);
     return true;
 }
@@ -244,6 +245,14 @@ public:
             auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
             network.createNode ();
             expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
+        }
+        {
+            beginTest ("Network deletes a child to ValueTree when deleting a node.");
+            Network network;
+            auto nodeId = network.createNode ();
+            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            network.eraseNode (nodeId);
+            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize - 1, "Network hasn't taken care of its tree.");
         }
     }
 } testTestNetwork;

--- a/Source/crdtsimNetwork.cpp
+++ b/Source/crdtsimNetwork.cpp
@@ -10,6 +10,8 @@ int Network::createNode ()
     auto newNode = Node{lastNodeIdentifier++};
     nodes.push_back (newNode);
     jassert (size () > 0);
+    valueTree.getOrCreateChildWithName (getNodeIdentifier (nodes.back ().getIdentifier ()), nullptr);
+    jassert (valueTree.getNumChildren () > 0);
     return nodes.back ().getIdentifier ();
 }
 const Node* Network::getNode (int identifier) const
@@ -101,6 +103,10 @@ void Network::eraseAllConnexionsWithNode (int nodeIdentifier)
 juce::ValueTree& Network::getValueTree ()
 {
     return valueTree;
+}
+juce::Identifier Network::getNodeIdentifier (int nodeIdentifier)
+{
+    return juce::String ("NODE#" + std::to_string (nodeIdentifier));
 }
 
 
@@ -231,6 +237,13 @@ public:
             network.eraseNode (nodeIdentifier2);
             expect (!network.connexionExists (nodeIdentifier1, nodeIdentifier2));
             expect (!network.connexionExists (nodeIdentifier2, nodeIdentifier3));
+        }
+        {
+            beginTest ("Network creates a child to ValueTree when creating a node.");
+            Network network;
+            auto initialValueTreeSize = network.getValueTree ().getNumChildren ();
+            network.createNode ();
+            expectEquals (network.getValueTree ().getNumChildren (), initialValueTreeSize + 1, "Network hasn't taken care of its tree.");
         }
     }
 } testTestNetwork;

--- a/Source/crdtsimNetwork.h
+++ b/Source/crdtsimNetwork.h
@@ -17,7 +17,8 @@ public:
     bool createConnexion (int sourceIdentifier, int destinationIdentifier);
     bool eraseConnexion (int sourceIdentifier, int destinationIdentifier);
     bool connexionExists (int sourceIdentifier, int destinationIdentifier);
-    juce::ValueTree& getValueTree ();
+    juce::ValueTree getNodesValueTree ();
+    juce::ValueTree getConnexionsValueTree ();
 
 private:
     std::vector<Node> nodes;

--- a/Source/crdtsimNetwork.h
+++ b/Source/crdtsimNetwork.h
@@ -27,6 +27,7 @@ private:
     void eraseAllConnexionsWithNode (int nodeIdentifier);
     juce::ValueTree valueTree;
     static juce::Identifier getNodeIdentifier (int nodeIdentifier);
+    static juce::Identifier getConnexionIdentifier (int sourceIdentifier, int destinationIdentifier);
 };
 } //crdtsim
 #endif // NETWORK_H_INCLUDED

--- a/Source/crdtsimNetwork.h
+++ b/Source/crdtsimNetwork.h
@@ -3,11 +3,13 @@
 #include <vector>
 #include "crdtsimNode.h"
 #include "crdtsimConnexion.h"
+#include "JuceHeader.h"
 namespace crdtsim
 {
 class Network
 {
 public:
+    Network ();
     int size () const;
     int createNode ();
     const Node* getNode (int identifier) const;
@@ -15,6 +17,7 @@ public:
     bool createConnexion (int sourceIdentifier, int destinationIdentifier);
     bool eraseConnexion (int sourceIdentifier, int destinationIdentifier);
     bool connexionExists (int sourceIdentifier, int destinationIdentifier);
+    juce::ValueTree& getValueTree ();
 
 private:
     std::vector<Node> nodes;
@@ -22,6 +25,7 @@ private:
     std::vector<Connexion> connexions;
 
     void eraseAllConnexionsWithNode (int nodeIdentifier);
+    juce::ValueTree valueTree;
 };
 } //crdtsim
 #endif // NETWORK_H_INCLUDED

--- a/Source/crdtsimNetwork.h
+++ b/Source/crdtsimNetwork.h
@@ -26,6 +26,7 @@ private:
 
     void eraseAllConnexionsWithNode (int nodeIdentifier);
     juce::ValueTree valueTree;
+    static juce::Identifier getNodeIdentifier (int nodeIdentifier);
 };
 } //crdtsim
 #endif // NETWORK_H_INCLUDED

--- a/Source/crdtsimNetworkComponent.cpp
+++ b/Source/crdtsimNetworkComponent.cpp
@@ -41,6 +41,7 @@ void NetworkComponent::valueTreeChildAdded (ValueTree& parentTree, ValueTree& ch
         auto identifier = childWhichHasBeenAdded.getType ();
         auto newNote = new juce::TextButton{};
         newNote->setButtonText (identifier.toString ());
+        newNote->setSize (100, 100);
         addDocument (newNote, Colours::lightblue.withAlpha (0.6f), true);
     }
     else if (parentTree == connexionsValueTree)

--- a/Source/crdtsimNetworkComponent.cpp
+++ b/Source/crdtsimNetworkComponent.cpp
@@ -2,6 +2,15 @@
 
 using namespace crdtsim;
 
+class NodesMultiDocumentPanelWindow : public MultiDocumentPanelWindow
+{
+public:
+    NodesMultiDocumentPanelWindow (Colour backgroundColour) : MultiDocumentPanelWindow (backgroundColour)
+    {
+        setTitleBarButtonsRequired (DocumentWindow::closeButton, true);
+    }
+};
+
 NetworkComponent::NetworkComponent ()
 {
     useFullscreenWhenOneDocument (false);

--- a/Source/crdtsimNetworkComponent.cpp
+++ b/Source/crdtsimNetworkComponent.cpp
@@ -1,0 +1,8 @@
+#include "crdtsimNetworkComponent.h"
+
+using namespace crdtsim;
+
+bool NetworkComponent::tryToCloseDocument (juce::Component* component)
+{
+    //TODO
+}

--- a/Source/crdtsimNetworkComponent.cpp
+++ b/Source/crdtsimNetworkComponent.cpp
@@ -76,3 +76,7 @@ void NetworkComponent::valueTreeParentChanged (ValueTree& treeWhoseParentHasChan
 {
     //TODO
 }
+MultiDocumentPanelWindow* NetworkComponent::createNewDocumentWindow ()
+{
+    return new NodesMultiDocumentPanelWindow (getBackgroundColour ());
+}

--- a/Source/crdtsimNetworkComponent.cpp
+++ b/Source/crdtsimNetworkComponent.cpp
@@ -2,7 +2,67 @@
 
 using namespace crdtsim;
 
+NetworkComponent::NetworkComponent ()
+{
+    useFullscreenWhenOneDocument (false);
+    setLayoutMode (LayoutMode::FloatingWindows);
+}
 bool NetworkComponent::tryToCloseDocument (juce::Component* component)
+{
+    //TODO
+}
+void NetworkComponent::setNodesValueTree (juce::ValueTree newValueTree)
+{
+    nodesValueTree = newValueTree;
+    nodesValueTree.addListener (this);
+}
+void NetworkComponent::setConnexionsValueTree (juce::ValueTree newValueTree)
+{
+    connexionsValueTree = newValueTree;
+    connexionsValueTree.addListener (this);
+}
+void NetworkComponent::valueTreePropertyChanged (ValueTree& treeWhosePropertyHasChanged, const Identifier& property)
+{
+    //TODO
+}
+void NetworkComponent::valueTreeChildAdded (ValueTree& parentTree, ValueTree& childWhichHasBeenAdded)
+{
+    if (parentTree == nodesValueTree)
+    {
+        auto identifier = childWhichHasBeenAdded.getType ();
+        auto newNote = new juce::TextButton{};
+        newNote->setButtonText (identifier.toString ());
+        addDocument (newNote, Colours::lightblue.withAlpha (0.6f), true);
+    }
+    else if (parentTree == connexionsValueTree)
+    {
+        //TODO
+    }
+    else
+    {
+        jassertfalse;
+    }
+}
+void NetworkComponent::valueTreeChildRemoved (ValueTree& parentTree, ValueTree& childWhichHasBeenRemoved, int /*indexFromWhichChildWasRemoved*/)
+{
+    if (parentTree == nodesValueTree)
+    {
+        //TODO
+    }
+    else if (parentTree == connexionsValueTree)
+    {
+        //TODO
+    }
+    else
+    {
+        jassertfalse;
+    }
+}
+void NetworkComponent::valueTreeChildOrderChanged (ValueTree& parentTreeWhoseChildrenHaveMoved, int oldIndex, int newIndex)
+{
+    //TODO
+}
+void NetworkComponent::valueTreeParentChanged (ValueTree& treeWhoseParentHasChanged)
 {
     //TODO
 }

--- a/Source/crdtsimNetworkComponent.h
+++ b/Source/crdtsimNetworkComponent.h
@@ -17,6 +17,7 @@ public:
     void valueTreeChildRemoved (ValueTree& parentTree, ValueTree& childWhichHasBeenRemoved, int indexFromWhichChildWasRemoved) override;
     void valueTreeChildOrderChanged (ValueTree& parentTreeWhoseChildrenHaveMoved, int oldIndex, int newIndex) override;
     void valueTreeParentChanged (ValueTree& treeWhoseParentHasChanged) override;
+    MultiDocumentPanelWindow* createNewDocumentWindow () override;
 
 private:
     juce::ValueTree nodesValueTree, connexionsValueTree;

--- a/Source/crdtsimNetworkComponent.h
+++ b/Source/crdtsimNetworkComponent.h
@@ -4,10 +4,22 @@
 #include "JuceHeader.h"
 namespace crdtsim
 {
-class NetworkComponent : public juce::MultiDocumentPanel
+class NetworkComponent : public juce::MultiDocumentPanel,
+                         public juce::ValueTree::Listener
 {
 public:
+    NetworkComponent ();
     bool tryToCloseDocument (juce::Component* component) override;
+    void setNodesValueTree (juce::ValueTree newValueTree);
+    void setConnexionsValueTree (juce::ValueTree newValueTree);
+    void valueTreePropertyChanged (ValueTree& treeWhosePropertyHasChanged, const Identifier& property) override;
+    void valueTreeChildAdded (ValueTree& parentTree, ValueTree& childWhichHasBeenAdded) override;
+    void valueTreeChildRemoved (ValueTree& parentTree, ValueTree& childWhichHasBeenRemoved, int indexFromWhichChildWasRemoved) override;
+    void valueTreeChildOrderChanged (ValueTree& parentTreeWhoseChildrenHaveMoved, int oldIndex, int newIndex) override;
+    void valueTreeParentChanged (ValueTree& treeWhoseParentHasChanged) override;
+
+private:
+    juce::ValueTree nodesValueTree, connexionsValueTree;
 };
 } //namespace crdtsim
 #endif // CRDTSIMNETWORKCOMPONENT_H_INCLUDED

--- a/Source/crdtsimNetworkComponent.h
+++ b/Source/crdtsimNetworkComponent.h
@@ -1,0 +1,13 @@
+#ifndef CRDTSIMNETWORKCOMPONENT_H_INCLUDED
+#define CRDTSIMNETWORKCOMPONENT_H_INCLUDED
+
+#include "JuceHeader.h"
+namespace crdtsim
+{
+class NetworkComponent : public juce::MultiDocumentPanel
+{
+public:
+    bool tryToCloseDocument (juce::Component* component) override;
+};
+} //namespace crdtsim
+#endif // CRDTSIMNETWORKCOMPONENT_H_INCLUDED


### PR DESCRIPTION
- [x] Create a custom type `NodesMultiDocumentPanelWindow : public MultiDocumentPanelWindow` to hold NodeComps
- [x] Remove maximise button from windows -> override `virtual MultiDocumentPanelWindow* createNewDocumentWindow();` to return our custom type `NodesMultiDocumentPanelWindow`
# Display connexions `crdtsimConnexionComponent`
- [ ] Create new `juce::Component` that looks like `------------>--`. If two Nodes are interconnected, it may look like this `--------<--->-------`.
- [ ] Connexion becomes a listener of any Components `source` and `destination`. Inspiration from `Label::attachToComponent` > `componentParentHierarchyChanged` and `componentMovedOrResized`
# Logging + Command
- [ ] juce::ApplicationManager::invoke `node deleted`
- [ ] 
- [ ] 
